### PR TITLE
Speed up getting valid words

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.2.0
+VERSION = 1.3.0
 
 test:
 	docker build --target test -t anagrams-env .

--- a/anagrams/anagrams.py
+++ b/anagrams/anagrams.py
@@ -2,7 +2,7 @@
 import re
 
 from dlx import all_exact_covers
-from words.dictionary import get_valid_jumbles
+from words.dictionary import get_valid_jumbles, get_valid_words
 
 
 def get_anagrams(word):
@@ -13,19 +13,20 @@ def get_anagrams(word):
     numbers = [i for i in range(len(letters))]
     key = lambda nums: "".join([letters[i] for i in nums])
     print("Determining words that can be made from these letters... ...")
-    jumbles = get_valid_jumbles(numbers, key=key)
+    word_list = get_valid_words(letters)
     print("Done.")
-    word_list = set()
-    for jumble in jumbles:
-        word_list.add(key(jumble))
     print("Words found:")
     print(", ".join([jumble for jumble in word_list]))
 
     # TODO: add ability to filter words out of word_list.
+    # TODO: add ability to require certain words to appear in the final
+    # anagrams (NOTE: this will require updates to dlx.py).
+
+    number_list = words_to_nums(word_list, letters)
 
     print("\nAnagrams:")
     constraints = numbers
-    elements = jumbles
+    elements = number_list
     mapping = lambda element: element
     coded_anagrams = all_exact_covers(constraints, elements, mapping)
     anagrams = []
@@ -34,3 +35,45 @@ def get_anagrams(word):
         print(", ".join(anagram))
         anagrams.append(anagram)
     return anagrams
+
+
+def words_to_nums(word_list, letters):
+    """Converts list of words to list of list of numbers mapping to index
+    values of user's original word-or-phrase, taking duplicate letters into
+    account.
+    """
+    number_list = []
+    char_list = {}
+    for i in range(len(letters)):
+        char = letters[i]
+        char_list.setdefault(char, [])
+        char_list[char].append(i)
+    for word in word_list:
+        number_list += word_to_nums(word, char_list)
+
+    return number_list
+
+
+def word_to_nums(word, char_list):
+    nums = []
+    number_lists = []
+    for char in word:
+        number_lists.append(char_list[char])
+
+    nums = _expand_number_list(number_lists)
+
+    return nums
+
+
+def _expand_number_list(number_lists):
+    if not number_lists:
+        return []
+    elif len(number_lists) == 1:
+        return [[num] for num in number_lists[0]]
+    expanded_number_list = []
+    expanded_sub_list = _expand_number_list(number_lists[1:])
+    for num in number_lists[0]:
+        for l in expanded_sub_list:
+            if not num in l:
+                expanded_number_list.append([num] + l)
+    return expanded_number_list

--- a/anagrams/words/dictionary.py
+++ b/anagrams/words/dictionary.py
@@ -13,7 +13,7 @@ class Dictionary(object):
             "word_list.txt",
         )
         with open(word_list, "r") as f:
-            return f.read().split("\n")
+            return f.read().rstrip().split("\n")
 
     def valid_word(self, word):
         """Return True iff word is in the dictionary."""
@@ -74,3 +74,31 @@ def get_valid_jumbles(word, key=None, dictionary=None):
     jumbles = jumble(word)
     return [jumble for jumble in jumbles \
         if dictionary.valid_word(key(jumble))]
+
+
+def get_valid_words(word, dictionary=None):
+    if not dictionary:
+        dictionary = Dictionary()
+    valid_words = []
+    word_len = len(word)
+    char_count = {}
+    for char in word:
+        char_count.setdefault(char, 0)
+        char_count[char] += 1
+
+    for valid_word in dictionary.words:
+        if len(valid_word) > word_len:
+            continue
+        invalid_char = False
+        valid_word_char_count = {}
+        for char in valid_word:
+            valid_word_char_count.setdefault(char, 0)
+            valid_word_char_count[char] += 1
+            if (not char in char_count or \
+                    valid_word_char_count[char] > char_count[char]):
+                invalid_char = True
+                break
+        if not invalid_char:
+            valid_words.append(valid_word)
+
+    return valid_words

--- a/releaseNotes.md
+++ b/releaseNotes.md
@@ -2,6 +2,14 @@
 
 ## v1.*
 
+### v1.3.0 released on 2025-08-XX
+
+#### Internal Improvement
+
+* Added more efficient method of getting valid jumbles for larger input sizes.
+
+#### PR(s): https://github.com/JohnTSpeare/anagrams/pull/5
+
 ### v1.2.0 released on 2025-07-30
 
 #### Internal Improvements

--- a/releaseNotes.md
+++ b/releaseNotes.md
@@ -2,7 +2,7 @@
 
 ## v1.*
 
-### v1.3.0 released on 2025-08-XX
+### v1.3.0 released on 2025-12-17
 
 #### Internal Improvement
 

--- a/tests/test_anagrams.py
+++ b/tests/test_anagrams.py
@@ -12,31 +12,24 @@ class Test_Anagrams(unittest.TestCase):
         self.expected_letters = "test"
         self.expected_numbers = [0, 1, 2, 3]
 
-    @mock.patch("anagrams.anagrams.get_valid_jumbles")
+    @mock.patch("anagrams.anagrams.get_valid_words")
     @mock.patch("anagrams.anagrams.all_exact_covers")
-    def test_get_anagrams(self, mock_all_exact_covers, mock_get_valid_jumbles):
+    def test_get_anagrams(self, mock_all_exact_covers, mock_get_valid_words):
         """Test for get_anagrams."""
-        mock_get_valid_jumbles.return_value = [
-            [0, 1],
-            [2, 3],
-        ]
+        mock_get_valid_words.return_value = ["te", "st"]
         mock_all_exact_covers.return_value = [
             [[0, 1], [2, 3]],
         ]
 
         anagrams = get_anagrams(self.test_word)
         
-        # TODO: This is messy. Figure out a way to mock the lambdas
-        self.assertEqual(len(mock_get_valid_jumbles.call_args_list), 1)
-        self.assertEqual(
-            mock_get_valid_jumbles.call_args_list[0][0],
-            ([0, 1, 2, 3],),
-        )
+        mock_get_valid_words.assert_called_once_with("test")
 
+        # TODO: This is messy. Figure out a way to mock the lambdas
         self.assertEqual(len(mock_all_exact_covers.call_args_list), 1)
         self.assertEqual(
             mock_all_exact_covers.call_args_list[0][0][0:2],
-            ([0, 1, 2, 3], [[0, 1], [2, 3]]),
+            ([0, 1, 2, 3], [[0, 1], [3, 1], [2, 0], [2, 3]]),
         )
 
         self.assertEqual(anagrams, [["te", "st"]])

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -46,3 +46,15 @@ class Test_Jumbles(object):
         result = dictionary.get_valid_jumbles("test", dictionary=mock_dictionary)
         mock_jumble.assert_called_once_with("test")
         assert result == [[char for char in "word2"]]
+
+
+class Test_GetWords(object):
+    """Test module for get_valid_words."""
+    def test_get_valid_words(self):
+        class TestDictionary(object):
+            def __init__(self):
+                self.words = ["te", "st", "toolong", "xxxx", "tett"]
+        test_dictionary = TestDictionary()
+        valid_words = dictionary.get_valid_words(
+            "test", dictionary=test_dictionary)
+        assert valid_words == ["te", "st"]


### PR DESCRIPTION
The jumble algorithm becomes less efficient than simply checking every word in the dictionary very quickly, starting at inputs of around 7 characters or so. So switching to checking all words for now, may use jumble again in the future on smaller inputs